### PR TITLE
fix lifecycle methods in button and datepicker

### DIFF
--- a/src/lib/Button/index.js
+++ b/src/lib/Button/index.js
@@ -25,10 +25,6 @@ class Button extends React.Component {
     /* eslint-enable no-console */
   }
 
-  componentWillUpdate (nextProps, nextState, nextContext) {
-    this.prevContext = {...nextContext};
-  }
-
   componentDidUpdate () {
     const { focusIndex } = this.context;
     const { index } = this.props;

--- a/src/lib/DatePicker/DatePickerCalendar/index.js
+++ b/src/lib/DatePicker/DatePickerCalendar/index.js
@@ -29,15 +29,11 @@ class DatePickerCalendar extends React.Component {
     this.setDate(focus || selected || now());
   }
 
-  componentWillUpdate (nextProps, nextState, nextContext) {
-    this.prevContext = {...nextContext};
-  }
-
-  componentDidUpdate () {
-    const { focus } = this.context;
+  componentDidUpdate (prevProps, prevState) {
+    const { focus } = prevProps;
     if (
       focus &&
-      !isSameDay(this.prevContext.focus, focus)
+      !isSameDay(this.props.focus, focus)
     ) {
       this.setDate(focus);
     }


### PR DESCRIPTION
afaik this works? tests pass and keyboard nav appears to work correctly in DatePicker...
DatePickerCalendar is receiving a `focus` prop anyways here... https://github.com/collab-ui/collab-ui-react/blob/1c2ae3f0dd0d8251666afe168e5a8d6de67d9720/src/lib/DatePicker/index.js#L173
so it doesn't seem like this DatePickerCalendar needs `context.focus`?